### PR TITLE
Typo and documentation

### DIFF
--- a/console.py
+++ b/console.py
@@ -75,7 +75,7 @@ class HBNBCommand(cmd.Cmd):
             print(obj.id)
             obj.save()
         except SyntaxError:
-            print('** class name missing ** ')
+            print('** class name missing **')
         except NameError:
             print('** class doesn\'t exist **')
 

--- a/tests/test_models/__init__.py
+++ b/tests/test_models/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python3
+"""
+    Test package
+"""


### PR DESCRIPTION
- Fix error message typo in console.py
- Document __init__.py in test/test_models/